### PR TITLE
Removed depreciated lines from void_ergo

### DIFF
--- a/keyboards/handwired/void_ergo/config.h
+++ b/keyboards/handwired/void_ergo/config.h
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PRODUCT_ID 0x3535
 #define DEVICE_VER 0x0001
 #define MANUFACTURER Victor Lucachi
-#define DESCRIPTION A handwired split keyboard inspired by the Corne
+//#define DESCRIPTION A handwired split keyboard inspired by the Corne
 
 /* key matrix size */
 #define MATRIX_ROWS 8
@@ -37,5 +37,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEBOUNCE 5
 
 /* disable these deprecated features by default */
-#define NO_ACTION_MACRO
-#define NO_ACTION_FUNCTION
+//#define NO_ACTION_MACRO
+//#define NO_ACTION_FUNCTION

--- a/keyboards/handwired/void_ergo/fat/config.h
+++ b/keyboards/handwired/void_ergo/fat/config.h
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #define MATRIX_ROW_PINS { B1, B3, B2, B6 }
 #define MATRIX_COL_PINS { D4, C6, D7, E6, B4, B5 }
-#define UNUSED_PINS
+//#define UNUSED_PINS
 
 /* Encoder pins */
 #define ENCODERS_PAD_A { F6 }

--- a/keyboards/handwired/void_ergo/rules.mk
+++ b/keyboards/handwired/void_ergo/rules.mk
@@ -1,7 +1,7 @@
 # Build Options
 # change yes to no to disable
 #
-BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
+BOOTMAGIC_ENABLE = yes     # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = no        # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = yes        # Console for debug

--- a/keyboards/handwired/void_ergo/slim/config.h
+++ b/keyboards/handwired/void_ergo/slim/config.h
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #define MATRIX_ROW_PINS { B1, B3, B2, B6 }
 #define MATRIX_COL_PINS { D4, C6, D7, E6, B4, B5 }
-#define UNUSED_PINS
+//#define UNUSED_PINS
 
 /* Encoder pins */
 #define ENCODERS_PAD_A { F5 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
A few defines form config.h and the bootmagic from rules.mk had depreciated commands that prevented the firmware from compiling
<!--- Describe your changes in detail here. -->
Removing two defines and changing the option of BOOTMAGIC_ENABLE from lite to yes fixed this

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
